### PR TITLE
Make StdOutTestReporter fail when zero tests are run

### DIFF
--- a/source/StdOutTestReporter.gs
+++ b/source/StdOutTestReporter.gs
@@ -109,5 +109,9 @@ result hasPassed ifTrue: [
       printError: [:s | s << '✗ Executed ' << result runCount asString << ' tests with ' << result failureCount asString << ' failures and ' << result errorCount asString << ' errors.' ];
       printError: [:s | s << '#####################################################']
   ].
+result runCount strictlyPositive ifFalse: [
+  StdOutPrinter printError: 'No tests were executed.'.
+  ^ false
+].
 ^ result hasPassed
 %


### PR DESCRIPTION
`StdOutTestReporter` is executed only if we're requesting to run the tests. It makes no sense to not fail when there are no tests to run.